### PR TITLE
I18n trailing slash fix

### DIFF
--- a/content/faq/en/can-kitsu-scale-with-us.md
+++ b/content/faq/en/can-kitsu-scale-with-us.md
@@ -7,6 +7,9 @@ image: "change-management-kitsu.png"
 
 Whether you're a 5-person studio wrapping up your first short film or a 200-person production house juggling three simultaneous series, Kitsu grows with you at every stage.
 
+::user-logos
+::
+
 ## Built for Where You Are and Where You're Going
 
 Most studios start small. They cobble together spreadsheets, shared drives, and chat threads. And it works, until it doesn't.
@@ -18,6 +21,9 @@ The platform scales in every direction:
 - Team size: from a handful of artists to hundreds across multiple departments
 - Project volume: manage one short or ten simultaneous productions from a single workspace
 - Pipeline complexity: simple task tracking on day one, full API and DCC integrations when you're ready
+
+::quote-content-block{slug="cube"}
+::
 
 ## Multi-Project Management, Without the Chaos
 
@@ -46,6 +52,9 @@ You move between these as your needs evolve. CGWire's ops team handles the trans
 Kitsu is open source. Your data is yours, the codebase is auditable, and you're never dependent on a vendor's pricing decisions or roadmap pivots.
 
 The platform has been tested at scale. We help studios in 50+ countries run Kitsu in production today, from boutique agencies to large-scale studios. 
+
+::customer-story-content-block{slug="remembers"}
+::
 
 ## One Tool. Every Stage.
 

--- a/content/faq/en/change-management.md
+++ b/content/faq/en/change-management.md
@@ -11,6 +11,9 @@ Most studios fail at making new tools stick. Artists ignore the tracker and keep
 
 Kitsu solves fragmentation with a system people actually want to use without being told to do so.
 
+::customer-story-content-block{slug="remembers"}
+::
+
 ## Built for the Way Animation Teams Actually Work
 
 Kitsu is not a generic project management tool adapted to animation. It's designed specifically for animation, VFX, and game production.
@@ -22,6 +25,9 @@ Instead of forcing your team to adapt, it reflects workflows they already unders
 - Reviews, playlists, and approvals match how supervisors already give feedback  
 
 For an artist, this means opening Kitsu and immediately understanding what needs to be done.
+
+::quote-content-block{slug="makuta"}
+::
 
 ## Adoption Starts With Clarity
 
@@ -47,6 +53,9 @@ Instead of generic training, Kitsu's onboarding is aligned with real responsibil
 - Pipeline TDs integrate pipelines through the Python API and REST endpoints  
 
 We help each person become productive quickly.
+
+::customer-story-content-block{slug="miyu"}
+::
 
 ## Start Small, Scale Naturally
 
@@ -76,6 +85,9 @@ Kitsu eliminates that by acting as a flexible central hub:
 
 Instead of replacing one tool with another, you replace several disconnected tools with one coherent system.
 
+::customer-story-content-block{slug="fost"}
+::
+
 ## Documentation and Autonomy
 
 Adoption does not stop after onboarding.
@@ -103,6 +115,9 @@ Kitsu enables pipeline artists to extend the core features:
 
 Whether your team is fully remote or working on-site, the system adapts to your environment.
 
+::quote-content-block{slug="mdhr"}
+::
+
 ## Removing Pain Points
 
 When teams push back against new tools, it usually comes down to a few concerns:
@@ -120,6 +135,9 @@ Most teams notice the difference quickly with less noise, fewer misunderstanding
 Kitsu was created by people who understand both software and production.
 
 As a small, focused team, CGWire works closely with studios and continuously improves the product based on real-world usage. The platform is open source, widely used across dozens of countries, and trusted by hundreds of studios.
+
+::user-logos
+::
 
 That experience shows in one key area: adoption is treated as a core design principle.
 

--- a/content/faq/en/custom-integration.md
+++ b/content/faq/en/custom-integration.md
@@ -17,6 +17,9 @@ It is designed to sit at the center of your production as a shared source of tru
 
 Whether you run a lightweight setup or a structured pipeline with automation, you can keep what works. But we'll add what is missing.
 
+::customer-story-content-block{slug="fost"}
+::
+
 ## Your Production Data, Fully Accessible
 
 In many studios, production data ends up fragmented across spreadsheets, tracking tools, and internal scripts.
@@ -50,6 +53,9 @@ This reduces the amount of glue code your team has to maintain and makes integra
 
 Our developer tools are well documented.
 
+::quote-content-block{slug="mdhr"}
+::
+
 ## Connect Without Disrupting Artists
 
 One of the biggest risks when introducing a new system is disrupting artists.
@@ -62,6 +68,9 @@ Kitsu avoids that by integrating with Digital Content Creation tools instead of 
 - Status updates can be triggered by pipeline actions
 
 Artists stay focused on their work, and your production stays consistent and traceable.
+
+::quote-content-block{slug="adm"}
+::
 
 ## Real-Time Collaboration Without Extra Overhead
 
@@ -109,7 +118,13 @@ You can understand how your data is structured, audit how the system works, host
 
 At the same time, CGWire provides managed cloud hosting and custom infrastructure setups if you prefer a fully supported solution.
 
+::quote-content-block{slug="cube"}
+::
+
 ## A Practical Fit for Real Studios
+
+::user-logos
+::
 
 Kitsu is used by hundreds of studios across different sizes and production types. Some use it out of the box to organize tasks and reviews. Others build advanced pipelines on top of it using its API and integrations.
 

--- a/content/faq/en/do-we-lose-control-over-our-production-pipeline.md
+++ b/content/faq/en/do-we-lose-control-over-our-production-pipeline.md
@@ -9,6 +9,9 @@ If your studio runs on spreadsheets, shared drives, or internal tools stitched t
 
 Here is how Kitsu addresses this concern.
 
+::user-logos
+::
+
 ## The Hidden Cost of "Familiar" Tools
 
 Spreadsheets feel controllable because you built them. But ask yourself: who actually knows how they work? When a producer leaves, does the logic leave with them?
@@ -16,6 +19,9 @@ Spreadsheets feel controllable because you built them. But ask yourself: who act
 This is a risk of siloed knowledge. And it's one of the most common ways studios lose control quietly over time: critical information lives in someone's head, a local file, or an inbox thread nobody can find.
 
 Kitsu turns implicit knowledge into structured, visible, searchable data, owned by your studio, not by any individual.
+
+::customer-story-content-block{slug="remembers"}
+::
 
 ## Permissions That Mirror Your Studio
 
@@ -26,6 +32,9 @@ Kitsu's role-based permissions let you define exactly who sees what and who can 
 - Artists see only their to-do list, their feedback, their deadlines
 
 No more "oops, someone edited the wrong thing." No more wondering who changed a status and when.
+
+::customer-story-content-block{slug="tant-mieux"}
+::
 
 ## Every Action Is Logged
 
@@ -41,6 +50,12 @@ Kitsu production reports and dashboards give you a 360° view across all active 
 
 Your managers stop being information brokers and make better decisions.
 
+::customer-story-content-block{slug="fost"}
+::
+
+::quote-content-block{slug="cube"}
+::
+
 ## Your Data, Your Way
 
 Kitsu is open-source. Your production data is exposed through a full REST API and Python client, so you can export, integrate, or migrate it at any time. There is no lock-in.
@@ -48,3 +63,6 @@ Kitsu is open-source. Your production data is exposed through a full REST API an
 Whether you choose cloud hosting, on-premise deployment on your own servers, or a custom self-hosted architecture tailored to your infrastructure, you stay in control of where your data lives.
 
 Control is about knowing what's happening, who did what, and what comes next. Kitsu gives your whole studio that clarity without depending on the one person who built the spreadsheet.
+
+::quote-content-block{slug="ryff"}
+::

--- a/content/faq/en/how-long-until-we-see-value.md
+++ b/content/faq/en/how-long-until-we-see-value.md
@@ -9,6 +9,9 @@ Switching tools always feels risky. You might wonder, "how long before it works 
 
 Your team can be tracking tasks, reviewing assets, and logging time within hours of signing up.
 
+::user-logos
+::
+
 ## Week 1 Looks Like This
 
 Day 1. You're live.
@@ -23,23 +26,25 @@ Upload a preview, leave timestamped annotations, compare versions side by side. 
 End of week 1. You have a production dashboard.
 Progress by task status, time logged per artist, asset readiness at a glance. The kind of report that used to take a producer half a day to compile manually.
 
+::quote-content-block{slug="miyu"}
+::
+
 ## What Makes This Fast
 
-Starter pipeline templates
-Pre-built task workflows for the most common production types. Pick one, customize later. You're not designing your pipeline from scratch.
+- Starter pipeline templates - Pre-built task workflows for the most common production types. Pick one, customize later. You're not designing your pipeline from scratch.
+- Flat learning curve for artists - The artist view is a simple task list with a preview upload button. If your team can use email, they can use Kitsu.
+- No IT project required - Cloud hosting means zero infrastructure work on your end. Kitsu handles SSL, uptime, backups, and video processing. You handle your production.
+- Data import tools - Bring in your asset lists and shot breakdowns from spreadsheets. Your existing tracking data doesn't go to waste.
 
-Flat learning curve for artists
-The artist view is a simple task list with a preview upload button. If your team can use email, they can use Kitsu.
-
-No IT project required
-Cloud hosting means zero infrastructure work on your end. Kitsu handles SSL, uptime, backups, and video processing. You handle your production.
-
-Data import tools
-Bring in your asset lists and shot breakdowns from spreadsheets. Your existing tracking data doesn't go to waste.
+::quote-content-block{slug="ryff"}
+::
 
 ## The Studios That Moved Fastest
 
 Studios across 50+ countries from small agencies to large VFX houses have made this switch without pausing a live production. The key was starting small: one project, one team, real work.
+
+::quote-content-block{slug="fost"}
+::
 
 ## Still Not Sure? Start Free.
 

--- a/content/faq/en/ip-protection.md
+++ b/content/faq/en/ip-protection.md
@@ -23,6 +23,9 @@ If you need to leave, you export your data. No negotiation, no proprietary forma
 
 Many studios only realize the cost of lock in when they try to switch tools mid production.
 
+::quote-content-block{slug="tant-mieux"}
+::
+
 ## Cloud Does Not Mean Loss Of Control
 
 The fear usually comes from not knowing where the data lives or who can access it.
@@ -43,6 +46,9 @@ You can run it on your own infrastructure. Same tool, same workflow, fully insid
 
 Because Kitsu is open source, there is no black box. Your technical team can inspect how everything works, integrate it into your pipeline, and adapt it if required. No need to trust what you cannot see.
 
+::quote-content-block{slug="ryff"}
+::
+
 ## Security That Fits Production Reality
 
 Security is about how people actually work.
@@ -56,6 +62,9 @@ Artists can publish previews directly from their DCC tools. Reviews happen insid
 At the same time, role-based permissions ensure that only the right people can access sensitive shots or assets.
 
 Rather than adding extra steps, we help you replace risky workflows with proven technology.
+
+::customer-story-content-block{slug="makuta"}
+::
 
 ## Backups And Recovery Without Extra Work
 
@@ -73,9 +82,15 @@ CGWire is not a generic software vendor. It is a small team focused entirely on 
 
 That focus shows in how Kitsu is designed.
 
+::quote-content-block{slug="adm"}
+::
+
 The platform is a live hub where tasks, assets, reviews, schedules, and communication are connected. The centralization reduces the number of places where sensitive data could be duplicated or lost.
 
 Studios in more than 50 countries use Kitsu in real production environments as a core part of their pipeline.
+
+::user-logos
+::
 
 ## The Takeaway
 
@@ -88,3 +103,6 @@ Kitsu checks all boxes. You can use it in the cloud with strong safeguards and n
 Either way, you'll never have to give up control.
 
 And in production, it makes the difference between a system that slows the team down and one that actually helps the work move forward.
+
+::customer-story-content-block{slug="fost"}
+::

--- a/content/faq/en/is-kitsu-too-complicated-for-our-team.md
+++ b/content/faq/en/is-kitsu-too-complicated-for-our-team.md
@@ -11,6 +11,9 @@ Most production tools are built for producers, and then handed to artists who ju
 
 Kitsu was designed differently: each role gets exactly what they need.
 
+::customer-story-content-block{slug="remembers"}
+::
+
 ## What an Artist Actually Sees
 
 When an artist logs into Kitsu, they don't land on a dashboard of Gantt charts, budget modules, or studio-wide reports. They see their to-do list.
@@ -26,6 +29,9 @@ That's it.
 - ✅ Move on
 
 No training required. No manual to read. No settings to configure.
+
+::customer-story-content-block{slug="miyu"}
+::
 
 ## What a Producer Actually Sees
 
@@ -68,7 +74,13 @@ Every screen in Kitsu is designed around a single question: what does this perso
 
 There are no cluttered sidebars fighting for attention. No ten-step workflows to publish a preview. No buried menus where critical actions hide.
 
+::quote-content-block{slug="woodblock"}
+::
+
 ## Trusted by 300+ Studios in 50+ Countries
+
+::user-logos{withTitle=false}
+::
 
 Studios ranging from solo freelancers to large-scale feature film productions use Kitsu daily, including teams that had never used dedicated production software before.
 

--- a/content/faq/en/is-kitsu-worth-the-cost.md
+++ b/content/faq/en/is-kitsu-worth-the-cost.md
@@ -16,9 +16,21 @@ You're already spending:
 - Onboarding and knowledge loss - Every time a new freelancer joins, someone has to teach them where things live. Without a centralized system, that orientation eats 2–4 hours of a senior team member's time per hire.
 - Miscommunication between departments - When artists don't know their task priorities, and supervisors don't know what's blocked, work piles up in the wrong places. Studios report that unclear task visibility leads to 10–20% of capacity being spent on work that has to be redone or was deprioritized too late.
 
+::customer-story-content-block{slug="remembers"}
+::
+
 ## What Studios Actually Save
 
 These aren't assumptions. They're patterns we see consistently across studios that switched to Kitsu:
+
+::quote-content-block{slug="tant-mieux"}
+::
+
+::quote-content-block{slug="fost"}
+::
+
+::quote-content-block{slug="cube"}
+::
 
 ## A Simple ROI Framework
 
@@ -54,3 +66,9 @@ If you're building a business case for your studio head or finance team, here's 
 3. Compare against Kitsu's plan cost for your team size
 
 The math usually resolves itself. How long can you afford to wait?
+
+::customer-story-content-block{slug="miyu"}
+::
+
+::user-logos{withTitle=false}
+::

--- a/content/faq/en/migration.md
+++ b/content/faq/en/migration.md
@@ -5,6 +5,9 @@ subtitle: "A Practical Approach to Moving Your Studio to Kitsu"
 image: "migration-kitsu-cloud.png"
 ---
 
+::user-logos{withTitle=false}
+::
+
 ## Switching Without Slowing Down Production
 
 Every studio hesitates before changing its production tracker. You have deadlines, artists in the middle of shots, and producers relying on stable data every day.
@@ -16,6 +19,9 @@ Kitsu is built with that reality in mind.
 We do not force a sudden change. We let studios transition at their own pace while production goes on. 
 
 You can move one project at a time, or even one department at a time, without interrupting deliveries.
+
+::customer-story-content-block{slug="miyu"}
+::
 
 ## A Migration Plan That Matches How Studios Actually Work
 
@@ -47,6 +53,9 @@ Kitsu allows you to import structured data through CSV or API, so you can bring 
 
 If you are coming from another tool, Kitsu helps you extract and reorganize that data so it fits cleanly.
 
+::quote-content-block{slug="tant-mieux"}
+::
+
 ## Running Both Systems If You Need Reassurance
 
 Some studios prefer to validate everything before committing.
@@ -67,6 +76,9 @@ Kitsu avoids that by focusing on how different roles actually operate:
 
 Training is adapted to each role with live sessions, practical examples, and direct support during rollout. We make sure each person understands how Kitsu helps them do their job faster.
 
+::quote-content-block{slug="woodblock"}
+::
+
 ## Integration Without Rebuilding Your Pipeline
 
 Most studios already have a working pipeline. Their concern is whether a new tool will force a rebuild.
@@ -82,6 +94,9 @@ With its REST API and Python client, your technical team can connect it to:
 - Review workflows already used by supervisors
 
 An artist can publish a playblast from their DCC tool and have it automatically appear in Kitsu with the correct task and version without manual upload.
+
+::customer-story-content-block{slug="makuta"}
+::
 
 ## Open Source Means Control, Not Dependency
 
@@ -110,3 +125,6 @@ With Kitsu, you can move progressively, keep production running, preserve your d
 Keep in mind that if your current system is creating friction between departments, staying with it also has a cost.
 
 Migrating to Kitsu is not about changing tools for the sake of it: we give your studio a system that scales with your projects and supports your team without adding unnecessary complexity.
+
+::customer-story-content-block{slug="fost"}
+::

--- a/content/faq/en/what-happens-if-something-breaks.md
+++ b/content/faq/en/what-happens-if-something-breaks.md
@@ -5,6 +5,9 @@ subtitle: ""
 image: "change-management-kitsu.png"
 ---
 
+::user-logos{withTitle=false}
+::
+
 Production doesn't pause for technical issues. When something goes wrong at 2 AM before a client review, the last thing you need is a support ticket disappearing into a void. 
 
 Here's exactly what you can count on with Kitsu.
@@ -16,6 +19,9 @@ CGWire is a focused team of specialists. When you reach out, you're talking to p
 - Dedicated support for cloud and on-premise customers, with clear response time commitments based on your plan
 - Direct access to the team. No tiered script-reading, no runaround
 - A community that's got your back. Kitsu is open source and backed by an active community of 300+ studios across 50+ countries. Chances are someone has already solved your problem.
+
+::customer-story-content-block{slug="ryff"}
+::
 
 ## Uptime You Can Actually Rely On
 
@@ -35,6 +41,9 @@ Getting set up and getting your whole team up to speed shouldn't require a consu
 - A full REST API and Python client with extensive documentation, so your pipeline team can integrate without guesswork
 - DCC integrations, chat integrations (Slack, Discord), and step-by-step guides for every major workflow
 
+::customer-story-content-block{slug="miyu"}
+::
+
 ## Open Source as a Safety Net
 
 Kitsu being open source is a practical guarantee. If CGWire ever ceased to exist tomorrow (it won't), you would still have full access to the codebase, your data, and a global community of developers who know the software inside out. You are never held hostage.
@@ -46,3 +55,6 @@ Something breaking is never zero-risk, with any tool.
 The real question is: who's there when it does? 
 
 With Kitsu, you have a dedicated ops team, a transparent company, a living community, and a codebase you can always inspect. That's a support structure most enterprise tools can't match.
+
+::customer-story-content-block{slug="fost"}
+::

--- a/content/faq/en/why-not-just-use-spreadsheets-or-notion.md
+++ b/content/faq/en/why-not-just-use-spreadsheets-or-notion.md
@@ -5,6 +5,9 @@ subtitle: ""
 image: "change-management-kitsu.png"
 ---
 
+::user-logos{withTitle=false}
+::
+
 We get it. The tool you have is the one you know. But "good enough" has a price: overtime, missed deliveries, and burnout.
 
 ## The Honest Question
@@ -14,6 +17,9 @@ Every studio we talk to has tried to make it work with existing tools. Spreadshe
 Then production scales. Deadlines compress. The team doubles. And suddenly "good enough" becomes the thing slowing everything down.
 
 ## Where Generic Tools Break Down
+
+::customer-story-content-block{slug="adm"}
+::
 
 ### Spreadsheets: Built for Numbers, Not Pipelines
 
@@ -52,6 +58,9 @@ ShotGrid (or Shotgun, or Flow) is a legitimate production tool. But it comes wit
 
 ShotGrid was built for large VFX facilities with dedicated infrastructure teams. If that's you, it may serve you well. If it's not, you're paying enterprise prices for features you don't need, while wrestling with a UI that wasn't designed for your workflow.
 
+::customer-story-content-block{slug="ryff"}
+::
+
 ## The Hidden Costs of "Good Enough"
 
 The sticker price of free tools is never the real price. Consider what you're actually spending:
@@ -67,6 +76,9 @@ The sticker price of free tools is never the real price. Consider what you're ac
 
 All these costs show up as crunch, turnover, and blown budgets.
 
+::customer-story-content-block{slug="fost"}
+::
+
 ## The Specific Pain Points Kitsu Was Built to Solve
 
 - Versioning: Every preview upload in Kitsu is versioned automatically. Supervisors review the latest version. Artists always know which feedback applies to which iteration. There is no "wait, which file are we looking at?"
@@ -81,3 +93,6 @@ Because the cost of switching is finite, the cost of staying is ongoing.
 Migrating to Kitsu typically takes days, not months. The open-source version costs nothing to try. And because your data is exposed via a full REST and Python API, Kitsu integrates with whatever pipeline tools you already use.
 
 The studios that delay the switch do it because switching feels risky. We've built Kitsu to make that risk as small as possible.
+
+::quote-content-block{slug="mdhr"}
+::

--- a/content/faq/en/will-kitsu-slow-us-down.md
+++ b/content/faq/en/will-kitsu-slow-us-down.md
@@ -11,6 +11,9 @@ But Kitsu was built by people who've lived inside productions.
 
 The design principle is simple: if it doesn't save time, it doesn't ship.
 
+::user-logos{withTitle=false}
+::
+
 ## The Real Cost of Not Having a Shared System
 
 Consider what "no tool" actually looks like in practice:
@@ -22,6 +25,9 @@ Consider what "no tool" actually looks like in practice:
 
 This is the baseline.
 
+::customer-story-content-block{slug="tant-mieux"}
+::
+
 ## Real-Time Updates, Not Manual Syncing
 
 Kitsu's activity feed and notification system mean the moment a task status changes, everyone who needs to know is informed automatically. No follow-up message required, no end-of-day summary email, no "just checking in" ping.
@@ -30,6 +36,9 @@ Artists update their own task statuses directly. Supervisors see the change imme
 
 It'll replace recurring check-ins, status spreadsheets, and the informal "where are we on this?" conversations that quietly eat hours every week.
 
+::customer-story-content-block{slug="fost"}
+::
+
 ## Faster Approvals, Fewer Bottlenecks
 
 The review loop is often where productions stall. A supervisor is traveling. Notes get buried in a thread. Two versions get confused. Retakes pile up because feedback wasn't specific enough.
@@ -37,6 +46,9 @@ The review loop is often where productions stall. A supervisor is traveling. Not
 Kitsu's review engine lets supervisors annotate directly on the frame, compare two versions side by side, and approve or request retakes in a single action from anywhere. Team review rooms allow synchronized playback so the whole team reacts together, in real time, without scheduling a screening.
 
 Approval cycles that used to take days can happen in hours because artists get precise, actionable feedback faster, and fewer shots need a third or fourth pass.
+
+::quote-content-block{slug="cube"}
+::
 
 ## Integrations That Remove Steps, Not Add Them
 
@@ -48,8 +60,14 @@ Kitsu connects to the tools studios already use: DCCs, Slack, Discord, and any p
 
 We make Kitsu invisible in the right places: present enough to keep everyone aligned, unobtrusive enough that artists stay in flow.
 
+::customer-story-content-block{slug="makuta"}
+::
+
 ## Built for Productions That Can't Afford to Slow Down
 
 Over 300 studios across 50+ countries run their productions on Kitsu, from short-form animation to feature films and video game pipelines. 
 
 They all adopted it because they didn't have time to spare!
+
+::customer-story-content-block{slug="ryff"}
+::

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -86,7 +86,8 @@ export default defineNuxtConfig({
       }
     ],
     lazy: true,
-    langDir: 'locales/'
+    langDir: 'locales/',
+    detectBrowserLanguage: false
   },
   plugins: [
     { src: '~/plugins/youtube', mode: 'client', ssr: false },

--- a/public/_redirects
+++ b/public/_redirects
@@ -9,6 +9,7 @@
 /shotgrid /shotgrid-alternative/
 /ftrack /ftrack-alternative/
 
+/fr /fr/
 /fr/about /fr/a-propos
 /fr/customer-stories /fr/temoignages-clients
 /fr/pricing /fr/tarifs
@@ -56,6 +57,7 @@
 /fr/kitsu.html                             /fr/kitsu/
 /fr/shotgrid/                              /fr/shotgrid-alternative/
 
+/ja /ja/
 /ja/about /ja/%E4%BC%81%E6%A5%AD%E6%83%85%E5%A0%B1/
 /ja/contact /ja/%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B/
 /ja/customer-stories /ja/%E5%B0%8E%E5%85%A5%E4%BA%8B%E4%BE%8B/


### PR DESCRIPTION
- disable auto language redirect
- add trailing slash redirect rule for languages

Problem
- nuxt detects selected language and stores it in cookie
- when navigating to a different locale, nuxt auto-redirects to the corresponding page in the prefered locale without a trailing slash
- in production, nuxt router is unable to load the route without trailing slash somehow 
- this behavior cannot be configured according to the docs

Solution
- disable language auto-redirect on client