### PR TITLE
implemented A/B testing logic for Nuxt + matomo

### DIFF
--- a/app/components/ExitIntentPopup.vue
+++ b/app/components/ExitIntentPopup.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport v-if="variant === 'variant_b'" to="body">
     <Transition name="modal">
       <div
         v-if="visible"
@@ -48,6 +48,11 @@
 
 <script setup>
 import { onMounted, onBeforeUnmount, ref } from "vue";
+
+const variant = useABTest('exit_intent_popup_test', [
+  { name: 'control', weight: 50 },
+  { name: 'variant_b', weight: 50 },
+])
 
 const visible = ref(false);
 const email = ref("");

--- a/app/composables/useABTests.js
+++ b/app/composables/useABTests.js
@@ -1,0 +1,28 @@
+function pickWeightedVariant(variants) {
+  const total = variants.reduce((sum, v) => sum + v.weight, 0)
+  let r = Math.random() * total
+  for (const v of variants) {
+    if (r < v.weight) return v.name
+    r -= v.weight
+  }
+  return variants[variants.length - 1].name
+}
+
+export function useABTest(testId, variants) {
+  const cookie = useCookie(`ab_${testId}`, {
+    maxAge: 60 * 60 * 24 * 90, // 90 days
+    sameSite: 'lax',
+  })
+
+  if (!cookie.value) {
+    cookie.value = pickWeightedVariant(variants)
+  }
+
+
+    if(import.meta.client && window._paq){
+    window._paq.push(['setCustomDimension', 1, cookie.value])
+    window._paq.push(['trackEvent', 'AB Test', '1', cookie.value])
+    }
+
+  return cookie // reactive ref, e.g. 'A' or 'B'
+}


### PR DESCRIPTION
- added new custom dimension in matomo
- added A/B testing logic as composable
- modified exit-intent popup for A/B testing (show to 50% of all visitors)
- added new tracking scope in matomo 