### PR TITLE
3D screenshots POC

### DIFF
--- a/app/components/ImageScene.vue
+++ b/app/components/ImageScene.vue
@@ -1,0 +1,101 @@
+<template>
+  <div ref="containerRef" class="image-scene" :class="{ 'is-loading': loading }">
+    <canvas ref="canvasRef" class="image-scene__canvas" />
+
+    <ClientOnly>
+      <div v-if="loading" class="image-scene__status">
+        Loading image…
+      </div>
+      <div v-else-if="error" class="image-scene__status image-scene__status--error">
+        {{ error }}
+      </div>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup>
+import { toRef } from 'vue'
+
+const props = defineProps({
+  src: {
+    type: String,
+    required: true,
+  },
+  // Background color of the 3D space (currently just informational — the
+  // renderer itself stays transparent so the page background shows through)
+  background: {
+    type: String,
+    default: '#0b0b0f',
+  },
+  tiltX: {
+    type: Number,
+    default: 0.35,
+  },
+  tiltY: {
+    type: Number,
+    default: -0.22,
+  },
+  baseDistance: {
+    type: Number,
+    default: 3.2,
+  },
+  zoomAmplitude: {
+    type: Number,
+    default: 10,
+  },
+  zoomSpeed: {
+    type: Number,
+    default: 0.4,
+  },
+})
+
+const { containerRef, canvasRef, loading, error, init } = useImageScene({
+  src: toRef(props, 'src'),
+  tiltX: props.tiltX,
+  tiltY: props.tiltY,
+  baseDistance: props.baseDistance,
+  zoomAmplitude: props.zoomAmplitude,
+  zoomSpeed: props.zoomSpeed,
+})
+
+// onMounted never runs during SSR, but guarding with import.meta.client
+// makes the client-only intent explicit and protects against any future
+// refactor (e.g. moving this call into a shared hook) that might not
+// preserve that guarantee.
+onMounted(() => {
+  if (import.meta.client) init()
+})
+</script>
+
+<style scoped>
+.image-scene {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.image-scene__canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.image-scene__status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #d8d8de;
+  font: 500 14px/1.4 system-ui, sans-serif;
+  letter-spacing: 0.02em;
+  pointer-events: none;
+}
+
+.image-scene__status--error {
+  color: #ff8080;
+}
+</style>

--- a/app/components/ThreeDFeatureBlock.vue
+++ b/app/components/ThreeDFeatureBlock.vue
@@ -1,0 +1,86 @@
+<template>
+  <section
+    :class="{
+      'block-colored': feature.colored,
+      gradient: feature.gradient === true,
+      [`gradient-${gradientStep}`]: gradientStep,
+      block: !feature.colored,
+      'has-bg-image': feature.image
+    }"
+  >
+     <ClientOnly fallback-tag="span">   
+
+      <ImageScene class="bg-image" :src="'/images/screenshots/' + feature.image" />
+
+      <template #fallback>
+        <NuxtImg
+        v-if="feature.image"
+        class="bg-image"
+        :src="'/images/screenshots/' + feature.image"
+        format="webp"
+        />
+      </template>
+    </ClientOnly>
+
+    <section class="section content-layer">
+      <div
+        :class="{
+          tile: true,
+          'flex-aic': true,
+          content: !feature.reverted,
+          'content-reverse': feature.reverted
+        }"
+      >
+        <div class="tile is-5 is-child content" data-aos="fade-up">
+          <h2>
+            <span class="section-subtitle">
+              {{ feature.subtitle }}
+            </span>
+            <span class="section-title">
+              {{ feature.title }}
+            </span>
+          </h2>
+          <p>
+            {{ feature.content }}
+          </p>
+        </div>
+      </div>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  feature: Object
+})
+
+const feature = props.feature
+
+const gradientStep = computed(() => {
+  if (typeof feature.gradient === 'number') return feature.gradient
+  return null
+})
+</script>
+
+<style lang="stylus" scoped>
+section
+  position relative
+  overflow hidden
+
+.bg-image
+  position absolute
+  inset 0
+  width 100%
+  height 100%
+  object-fit cover
+  z-index 0
+
+.content-layer
+  position relative
+  z-index 1
+
+.screenshot
+  border-radius 10px
+</style>

--- a/app/composables/useImageScene.js
+++ b/app/composables/useImageScene.js
@@ -1,0 +1,327 @@
+import { ref, shallowRef, watch, onBeforeUnmount } from 'vue'
+import { registerSharedScene, unregisterSharedScene, getTHREE } from './useSharedRenderer'
+
+// Kept as module-level constants — previously read off an OrbitControls
+// instance that was created solely to store these two numbers and never
+// actually enabled/updated. With a shared renderer, per-scene OrbitControls
+// don't make sense anyway (see note in buildScene), so these are just
+// plain constants now.
+const MIN_DISTANCE = 1.2
+const MAX_DISTANCE = 4
+
+/**
+ * useImageScene
+ *
+ * Encapsulates a tilted, slowly-breathing Three.js "image plane" scene so
+ * it can be reused across components without duplicating Three.js
+ * setup/teardown logic.
+ *
+ * Designed to be called once PER image — e.g. from inside a v-for over a
+ * list of screenshots. Each call gets its own Scene/camera/mesh/texture,
+ * but rendering itself is done by a single shared WebGLRenderer (see
+ * useSharedRenderer.js), per the Three.js manual's "multiple scenes, one
+ * renderer" pattern (https://threejs.org/manual/#en/multiple-scenes).
+ * That renderer draws onto one full-viewport canvas positioned over the
+ * page; each instance's `containerRef` element just defines the
+ * on-screen rectangle its scene gets rendered into (via scissor/viewport),
+ * so there's nothing shared between instances except that renderer, the
+ * ticker's rAF loop, and the browser's single WebGL context.
+ *
+ * Nuxt note: Three.js touches `window`/`document`/WebGL, none of which
+ * exist during SSR. By default this composable initializes itself lazily
+ * (see `lazy` option below) once its containerRef is mounted and near the
+ * viewport, so you generally do NOT need to call init() yourself. If you
+ * set `lazy: false`, call init() from a client-only lifecycle hook.
+ *
+ * @param {object} options
+ * @param {import('vue').Ref<string>|string} options.src - image URL (can be a ref for reactivity)
+ * @param {number} [options.tiltX]
+ * @param {number} [options.tiltY]
+ * @param {number} [options.baseDistance]
+ * @param {number} [options.zoomSpeed]
+ * @param {boolean} [options.lazy=true] - don't register with the shared
+ *   renderer until the container scrolls near the viewport. Still worth
+ *   doing even with a shared renderer/context: it avoids doing texture
+ *   loads and per-frame work for scenes nobody is looking at yet.
+ * @param {boolean} [options.disposeOnExit=false] - fully release this
+ *   scene's GPU-side resources (mesh geometry/material, texture) and
+ *   unregister from the shared render loop when the container scrolls far
+ *   out of view, rebuilding on re-entry. Note this no longer tears down a
+ *   WebGL *context* (there's only ever one, shared globally) — it frees
+ *   this instance's textures/geometry, which is still worthwhile on pages
+ *   with many large images. If false, the scene is just paused (resources
+ *   stay alive, rendering stops) while off-screen.
+ * @param {string} [options.rootMargin='200px'] - IntersectionObserver
+ *   rootMargin, controls how far ahead of scroll position scenes preload.
+ */
+export function useImageScene(options = {}) {
+  const {
+    src,
+    tiltX = 0.35,
+    tiltY = -0.22,
+    baseDistance = 3.2,
+    zoomSpeed = 0.4,
+    lazy = true,
+    disposeOnExit = false,
+    rootMargin = '200px',
+  } = options
+
+  const containerRef = ref(null)
+  // Vestigial: kept only so existing templates that render
+  // `<canvas ref="canvasRef">` don't break. It's no longer bound to a
+  // WebGLRenderer — all drawing happens on the single shared canvas — so
+  // new usages can safely drop the <canvas> element and rely on
+  // containerRef alone for layout/sizing.
+  const canvasRef = ref(null)
+  const loading = ref(true)
+  const error = ref(null)
+
+  // Three.js objects don't need to be deeply reactive — shallowRef avoids
+  // Vue proxying them (which is wasted work and can break Three internals).
+  const scene = shallowRef(null)
+  const camera = shallowRef(null)
+  const mesh = shallowRef(null)
+  const texture = shallowRef(null)
+
+  let THREE = null
+  let resizeObserver = null
+  let intersectionObserver = null
+  let clock = null
+  let disposed = false
+  let built = false // true once buildScene() has run
+  let viewDir = null
+  let phase = 0
+  let slot = null // this instance's registration with the shared renderer
+
+  async function loadThree() {
+    if (THREE) return
+    // Backed by the same dynamic import() cache as useSharedRenderer, so
+    // this resolves to the same module instance rather than re-fetching.
+    THREE = await getTHREE()
+  }
+
+  function buildScene() {
+    const container = containerRef.value
+    if (!container) return
+
+    const { clientWidth: width, clientHeight: height } = container
+    if (width === 0 || height === 0) return
+
+    scene.value = new THREE.Scene()
+
+    viewDir = new THREE.Vector3(tiltX, tiltY, 1).normalize()
+
+    camera.value = new THREE.PerspectiveCamera(45, width / height, 0.1, 100)
+    camera.value.position.copy(viewDir).multiplyScalar(baseDistance)
+    camera.value.lookAt(0, 0, 0)
+
+    scene.value.add(new THREE.AmbientLight(0xffffff, 0.7))
+    const key = new THREE.DirectionalLight(0xffffff, 0.8)
+    key.position.set(2, 2, 3)
+    scene.value.add(key)
+
+    // No OrbitControls here: this scene is rendered into a scissored
+    // rectangle of a full-viewport canvas that has pointer-events:none,
+    // so there's no sane DOM element for per-scene pointer listeners to
+    // attach to anyway. The gentle zoom motion below is driven manually.
+
+    clock = new THREE.Clock()
+    built = true
+  }
+
+  function loadTexture(url) {
+    if (!url || !THREE) return
+    loading.value = true
+    error.value = null
+
+    const loader = new THREE.TextureLoader()
+    loader.setCrossOrigin('anonymous')
+
+    loader.load(
+      url,
+      (loadedTexture) => {
+        if (disposed) {
+          loadedTexture.dispose()
+          return
+        }
+        texture.value = loadedTexture
+        texture.value.colorSpace = THREE.SRGBColorSpace
+
+        const { width: imgW, height: imgH } = texture.value.image
+        const aspect = imgW && imgH ? imgW / imgH : 1
+
+        const planeHeight = 2
+        const planeWidth = planeHeight * aspect
+        const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight)
+        const material = new THREE.MeshBasicMaterial({
+          map: texture.value,
+          transparent: true,
+          premultipliedAlpha: false,
+          depthWrite: false,
+          depthTest: false,
+        })
+
+        if (mesh.value) {
+          scene.value.remove(mesh.value)
+          mesh.value.geometry.dispose()
+          mesh.value.material.dispose()
+        }
+
+        mesh.value = new THREE.Mesh(geometry, material)
+        scene.value.add(mesh.value)
+
+        loading.value = false
+      },
+      undefined,
+      (err) => {
+        console.error('useImageScene: failed to load texture', err)
+        error.value = 'Could not load image.'
+        loading.value = false
+      }
+    )
+  }
+
+  // Passed to the shared renderer as this slot's `beforeRender` hook —
+  // called once per frame, right before the shared renderer draws this
+  // scene into its rectangle. Only touches the camera; the actual
+  // renderer.render() call lives in useSharedRenderer.js.
+  function updateCamera() {
+    if (disposed || !built || !clock) return
+
+    const delta = clock.getDelta()
+    phase += delta * zoomSpeed
+    const t = (Math.sin(phase) + 1) / 2
+    const distance = THREE.MathUtils.lerp(MIN_DISTANCE, MAX_DISTANCE, t)
+    camera.value.position.copy(viewDir).multiplyScalar(distance)
+    camera.value.lookAt(0, 0, 0)
+  }
+
+  // The shared renderer recomputes each scene's on-screen rect (and thus
+  // viewport size) every frame from containerRef directly, so this only
+  // needs to keep the camera's aspect ratio in sync when the container's
+  // size changes (e.g. a responsive layout reflow, not just a window
+  // resize).
+  function handleResize() {
+    if (!camera.value || !containerRef.value) return
+    const { clientWidth: width, clientHeight: height } = containerRef.value
+    if (width === 0 || height === 0) return
+    camera.value.aspect = width / height
+    camera.value.updateProjectionMatrix()
+  }
+
+  /**
+   * Build the scene, load the texture, and register with the shared
+   * render loop. Safe to call multiple times (e.g. after teardownGL()) —
+   * it rebuilds from scratch. You don't need to call this yourself unless
+   * you passed `lazy: false`.
+   */
+  async function init() {
+    await loadThree()
+    if (disposed) return
+
+    buildScene()
+    if (!built) return
+
+    loadTexture(typeof src === 'object' && 'value' in src ? src.value : src)
+
+    slot = { containerRef, scene: scene.value, camera: camera.value, beforeRender: updateCamera }
+    await registerSharedScene(slot)
+
+    if (!resizeObserver) {
+      resizeObserver = new ResizeObserver(handleResize)
+    }
+    resizeObserver.observe(containerRef.value)
+  }
+
+  /** Stop rendering (and camera animation) without freeing GPU resources. */
+  function pause() {
+    if (slot) unregisterSharedScene(slot)
+  }
+
+  /** Resume rendering after pause(), reusing this instance's existing scene. */
+  function resume() {
+    if (built && slot) registerSharedScene(slot)
+  }
+
+  /**
+   * Release this scene's GPU-side resources (mesh geometry/material,
+   * texture) and unregister from the shared render loop. Call init()
+   * again to rebuild. Used internally when `disposeOnExit: true`.
+   */
+  function teardownGL() {
+    if (!built) return
+
+    if (slot) {
+      unregisterSharedScene(slot)
+      slot = null
+    }
+    resizeObserver?.disconnect()
+
+    mesh.value?.geometry.dispose()
+    mesh.value?.material.dispose()
+    texture.value?.dispose()
+
+    scene.value = null
+    camera.value = null
+    mesh.value = null
+    texture.value = null
+
+    built = false
+    loading.value = true
+  }
+
+  /** Full teardown on unmount — never rebuilds after this. */
+  function dispose() {
+    disposed = true
+    intersectionObserver?.disconnect()
+    teardownGL()
+  }
+
+  // React to a reactive `src` (e.g. a prop passed in as a ref).
+  if (src && typeof src === 'object' && 'value' in src) {
+    watch(src, (newSrc) => {
+      if (newSrc && THREE && built) loadTexture(newSrc)
+    })
+  }
+
+  // Lazily build/pause/teardown based on viewport visibility. This is what
+  // makes it safe to drop many <ImageScene> instances on one landing page:
+  // below-the-fold scenes don't do texture loads or per-frame work until
+  // they're about to be scrolled into view.
+  watch(containerRef, (el) => {
+    if (!el) return
+
+    if (!lazy) {
+      init()
+      return
+    }
+
+    intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        const isVisible = entries[0]?.isIntersecting
+        if (isVisible) {
+          if (!built) init()
+          else resume()
+        } else if (built) {
+          if (disposeOnExit) teardownGL()
+          else pause()
+        }
+      },
+      { rootMargin }
+    )
+    intersectionObserver.observe(el)
+  })
+
+  onBeforeUnmount(dispose)
+
+  return {
+    containerRef,
+    canvasRef,
+    loading,
+    error,
+    init,
+    pause,
+    resume,
+    dispose,
+  }
+}

--- a/app/composables/useSharedRenderer.js
+++ b/app/composables/useSharedRenderer.js
@@ -1,0 +1,170 @@
+import { useThreeTicker } from './useThreeTicker'
+
+/**
+ * useSharedRenderer
+ *
+ * Per the Three.js manual's guidance on pages with many "scenes"
+ * (https://threejs.org/manual/#en/multiple-scenes), the recommended
+ * pattern is: ONE WebGLRenderer + ONE <canvas>, shared by every logical
+ * scene on the page. Browsers cap concurrent WebGL contexts (commonly
+ * ~8-16), and each renderer/context carries its own GPU memory and driver
+ * overhead — creating one per <ImageScene> (as the old implementation
+ * did) doesn't scale to a page with a dozen+ of them.
+ *
+ * This module owns that single renderer as a lazy singleton:
+ *  - The renderer/canvas are created the first time any scene registers,
+ *    and disposed once the last scene unregisters. A page that never
+ *    mounts an ImageScene never pays for a WebGL context at all.
+ *  - The shared <canvas> is `position: fixed`, sized to the viewport, and
+ *    `pointer-events: none` — it draws on top of the page but never
+ *    intercepts clicks/drags, so it's invisible to the rest of the page's
+ *    interaction model. Everywhere no mesh is drawn, the canvas is fully
+ *    transparent (alpha renderer + transparent clear color), so normal
+ *    page content behind/around it is unaffected.
+ *  - Each caller (see useImageScene.js) registers a "slot": its own
+ *    {containerRef, scene, camera, beforeRender}. Every tick, this module
+ *    walks the registered slots, reads each slot's on-screen rectangle
+ *    from containerRef.getBoundingClientRect(), and renders that slot's
+ *    scene into that rectangle via renderer.setViewport/setScissor. From
+ *    the outside it still looks like N independent canvases; under the
+ *    hood it's one GL context doing N scissored draws per frame.
+ *
+ * Individual scenes (mesh, geometry, material, texture, camera, Scene)
+ * are still owned per-instance by useImageScene — those are cheap. Only
+ * the expensive renderer/context is shared.
+ */
+
+let THREE = null
+let renderer = null
+let canvasEl = null
+let resizeHandler = null
+let ticker = null
+let tickerAttached = false
+const slots = new Set()
+
+async function loadThree() {
+  if (THREE) return THREE
+  THREE = await import('three')
+  return THREE
+}
+
+function createCanvas() {
+  const el = document.createElement('canvas')
+  Object.assign(el.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '100vw',
+    height: '100vh',
+    pointerEvents: 'none',
+  })
+  document.body.appendChild(el)
+  return el
+}
+
+function resizeRenderer() {
+  if (!renderer) return
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+  renderer.setSize(window.innerWidth, window.innerHeight, false)
+}
+
+async function ensureRenderer() {
+  if (renderer) return renderer
+  await loadThree()
+  // Guard against a second concurrent call building a second renderer
+  // while the first await above was in flight.
+  if (renderer) return renderer
+
+  canvasEl = createCanvas()
+  renderer = new THREE.WebGLRenderer({ canvas: canvasEl, antialias: true, alpha: true })
+  renderer.setClearColor(0x000000, 0)
+  resizeRenderer()
+
+  resizeHandler = resizeRenderer
+  window.addEventListener('resize', resizeHandler)
+
+  return renderer
+}
+
+function renderFrame() {
+  if (!renderer) return
+
+  // Wipe the whole shared canvas once per frame. Each slot below only
+  // clears/draws inside its own scissor rect, so a scene that unmounts
+  // (or shrinks) doesn't leave stale pixels behind.
+  renderer.setScissorTest(false)
+  renderer.clear()
+  renderer.setScissorTest(true)
+
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+
+  for (const slot of slots) {
+    const el = slot.containerRef?.value
+    if (!el || !slot.scene || !slot.camera) continue
+
+    const rect = el.getBoundingClientRect()
+    if (rect.width === 0 || rect.height === 0) continue
+    // Cheap offscreen culling. useImageScene's own IntersectionObserver
+    // already pauses/tears down scenes that are far off-screen; this
+    // just skips a render call for anything transiently past the edge.
+    if (rect.bottom < 0 || rect.top > vh || rect.right < 0 || rect.left > vw) continue
+
+    slot.beforeRender?.()
+
+    const x = rect.left
+    const y = vh - rect.bottom // flip to WebGL's bottom-left-origin viewport space
+    renderer.setViewport(x, y, rect.width, rect.height)
+    renderer.setScissor(x, y, rect.width, rect.height)
+    renderer.render(slot.scene, slot.camera)
+  }
+}
+
+/**
+ * Register a scene "slot" with the shared renderer. Builds the shared
+ * renderer/canvas on first call. Safe to call again to re-register a slot
+ * previously passed to unregisterSharedScene (e.g. on pause/resume).
+ * @param {{ containerRef: import('vue').Ref, scene: any, camera: any, beforeRender?: () => void }} slot
+ */
+export async function registerSharedScene(slot) {
+  await ensureRenderer()
+  slots.add(slot)
+
+  if (!tickerAttached) {
+    ticker = ticker ?? useThreeTicker()
+    ticker.add(renderFrame)
+    tickerAttached = true
+  }
+}
+
+/**
+ * Unregister a slot. Once the last slot anywhere unregisters, the shared
+ * renderer/canvas/context are fully disposed and the resize listener is
+ * removed — the next registerSharedScene() call rebuilds from scratch.
+ */
+export function unregisterSharedScene(slot) {
+  slots.delete(slot)
+  if (slots.size > 0) return
+
+  if (ticker && tickerAttached) {
+    ticker.remove(renderFrame)
+    tickerAttached = false
+  }
+
+  renderer?.dispose()
+  renderer = null
+
+  canvasEl?.remove()
+  canvasEl = null
+
+  if (resizeHandler) {
+    window.removeEventListener('resize', resizeHandler)
+    resizeHandler = null
+  }
+}
+
+/** Access to the shared (cached) THREE module, for callers that need it. */
+export async function getTHREE() {
+  await loadThree()
+  return THREE
+}

--- a/app/composables/useThreeTicker.js
+++ b/app/composables/useThreeTicker.js
@@ -1,0 +1,37 @@
+/**
+ * useThreeTicker
+ *
+ * A single shared requestAnimationFrame loop that all useImageScene
+ * instances register/unregister a per-frame callback with. Without this,
+ * a landing page with e.g. 12 <ImageScene> components would spin up 12
+ * independent rAF loops doing effectively the same scheduling work.
+ *
+ * Module-scoped by design: every import of this file shares the same
+ * `callbacks` set and `frameId`, regardless of how many components call
+ * useThreeTicker().
+ */
+
+const callbacks = new Set()
+let frameId = null
+
+function tick() {
+  frameId = requestAnimationFrame(tick)
+  for (const cb of callbacks) cb()
+}
+
+export function useThreeTicker() {
+  function add(cb) {
+    callbacks.add(cb)
+    if (frameId === null) tick()
+  }
+
+  function remove(cb) {
+    callbacks.delete(cb)
+    if (callbacks.size === 0 && frameId !== null) {
+      cancelAnimationFrame(frameId)
+      frameId = null
+    }
+  }
+
+  return { add, remove }
+}

--- a/app/layouts/features.vue
+++ b/app/layouts/features.vue
@@ -2,11 +2,20 @@
   <div v-if="page" :class="`kitsu-page ${pageKey}`">
     <SolutionHeaderBlock :page-key="page.slug" :header="page.meta.header" />
 
-    <FeatureBlock
+
+    <template
       v-for="(feature, index) in page.meta.features"
       :key="index"
-      :feature="feature"
-    />
+    >
+      <ThreeDFeatureBlock
+        v-if="feature.is3D"
+        :feature="feature"
+      />
+      <FeatureBlock
+        v-else
+        :feature="feature"
+      />
+    </template>
 
     <CustomerStoryBlock
       v-if="customerStory"

--- a/content/en_pages.json
+++ b/content/en_pages.json
@@ -1461,7 +1461,8 @@
           "content": "Assign tasks to artists and have them publish their work directly in Kitsu when ready for review. Producers, supervisors, and directors iterate on the same platform, with every comment and version tracked in context. Real-time notifications mean no one is waiting on information they should already have.",
           "image": "kitsu-tasks.png",
           "shadow": true,
-          "colored": true
+          "colored": true,
+          "is3D": true
         },
         {
           "key": "todos",
@@ -1470,7 +1471,8 @@
           "content": "Each artist sees exactly what is assigned to them, in what order, and at what stage. They can update progress without chasing a supervisor for instructions. Less back-and-forth means more time on the work that matters.",
           "image": "kitsu-todos.png",
           "shadow": true,
-          "reverted": true
+          "reverted": true,
+          "is3D": true
         },
         {
           "key": "supervision",
@@ -1479,7 +1481,8 @@
           "content": "Supervisors can instantly access a department-wide view of production through the Daily Supervision Tasks page. From any page in Kitsu, simply click on a task type name to see an overview of all related tasks across your department. This makes it easy to monitor progress, identify bottlenecks, review priorities, and ensure work keeps moving without manually collecting updates from artists.",
           "image": "kitsu-supervision.png",
           "shadow": true,
-          "colored": true
+          "colored": true,
+          "is3D": true
         },
         {
           "key": "news",
@@ -1488,7 +1491,8 @@
           "content": "The newsfeed surfaces every comment, status change, and new preview across the production in real time. Supervisors and producers spot issues early, before they compound. Nothing falls through the cracks because someone missed a message.",
           "image": "kitsu-news.png",
           "shadow": true,
-          "reverted": true
+          "reverted": true,
+          "is3D": true
         },
         {
           "title": "Slack and Discord notifications",


### PR DESCRIPTION
The idea is to make illustrations more engaging to drive conversion.

Instead of videos, we use 3D to create programmatic animations featuring the product UI. Combined with high-quality screenshots, the reader can see all the details.

  - renders 3D animation from screenshot
  - puts ThreeJS logic in composable
  - efficiently handles multiple 3D scenes using a single renderer

[Screencast from 07-02-2026 06:08:57 PM.webm](https://github.com/user-attachments/assets/9d92829c-e7a0-4251-81ca-de1edd82914b)
